### PR TITLE
Add HTTP caching utility

### DIFF
--- a/scripts/build_canonical.py
+++ b/scripts/build_canonical.py
@@ -1,19 +1,20 @@
+#!/usr/bin/env python
 import argparse
 import os
+import sys
 
 from crfgen.crawl import harvest, write_json
 
 
-def main() -> None:
-    parser = argparse.ArgumentParser(description="Build canonical CRF JSON")
-    parser.add_argument("--filter", dest="filter", help="Substring to match IG version", default=None)
-    parser.add_argument("--output", dest="output", help="Output JSON path", default="crf.json")
-    args = parser.parse_args()
+p = argparse.ArgumentParser()
+p.add_argument("-o", "--out", default="crf.json")
+p.add_argument("-v", "--version", help="IG version substring (optional)")
+args = p.parse_args()
 
-    token = os.environ["CDISC_PRIMARY_KEY"]
-    forms = harvest(token, ig_filter=args.filter)
-    write_json(forms, args.output)
+token = os.getenv("CDISC_PRIMARY_KEY")
+if not token:
+    sys.exit("ERROR: set CDISC_PRIMARY_KEY environment variable")
 
-
-if __name__ == "__main__":
-    main()
+forms = harvest(token, ig_filter=args.version)
+write_json(forms, args.out)
+print(f"✅  Saved {len(forms)} forms -> {args.out}")

--- a/scripts/build_canonical.py
+++ b/scripts/build_canonical.py
@@ -1,0 +1,19 @@
+import argparse
+import os
+
+from crfgen.crawl import harvest, write_json
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Build canonical CRF JSON")
+    parser.add_argument("--filter", dest="filter", help="Substring to match IG version", default=None)
+    parser.add_argument("--output", dest="output", help="Output JSON path", default="crf.json")
+    args = parser.parse_args()
+
+    token = os.environ["CDISC_PRIMARY_KEY"]
+    forms = harvest(token, ig_filter=args.filter)
+    write_json(forms, args.output)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/crfgen/converter.py
+++ b/src/crfgen/converter.py
@@ -7,24 +7,33 @@ from typing import Any
 from crfgen.schema import Form, FieldDef, Codelist
 
 
+def _get(obj: Any, key: str):
+    if isinstance(obj, dict):
+        return obj.get(key)
+    return getattr(obj, key)
+
+
 def field_from_api(f: Any) -> FieldDef:
+    codelist_obj = _get(f, "codelist")
     cl = (
-        Codelist(nci_code=f.codelist.nci_code, href=f.codelist.href)
-        if getattr(f, "codelist", None) else None
+        Codelist(nci_code=_get(codelist_obj, "nci_code"), href=_get(codelist_obj, "href"))
+        if codelist_obj
+        else None
     )
     return FieldDef(
-        oid=f.cdash_variable,
-        prompt=f.prompt,
-        datatype=f.datatype,
-        cdash_var=f.cdash_variable,
+        oid=_get(f, "cdash_variable"),
+        prompt=_get(f, "prompt"),
+        datatype=_get(f, "datatype"),
+        cdash_var=_get(f, "cdash_variable"),
         codelist=cl,
     )
 
 
 def form_from_api(payload: Any) -> Form:
+    fields_data = _get(payload, "fields") or []
     return Form(
-        title=payload.title,
-        domain=payload.domain,
-        scenario=getattr(payload, "scenario", None),
-        fields=[field_from_api(f) for f in payload.fields],
+        title=_get(payload, "title"),
+        domain=_get(payload, "domain"),
+        scenario=_get(payload, "scenario"),
+        fields=[field_from_api(f) for f in fields_data],
     )

--- a/src/crfgen/crawl.py
+++ b/src/crfgen/crawl.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+from typing import List, Optional
+import time
+import json
+import pathlib
+
+from cdisc_library_client.client import AuthenticatedClient
+from crfgen.converter import form_from_api
+from crfgen.schema import Form
+from crfgen.http import cached_get
+
+BASE = "https://library.cdisc.org/api"
+ACCEPT = "application/vnd.cdisc+json"
+DELAY = 0.2  # seconds between calls (<= 60 req/min)
+
+
+def _client(token: str) -> AuthenticatedClient:
+    return AuthenticatedClient(base_url=BASE, token=token, timeout=30.0)
+
+
+def _json(url: str, token: str):
+    headers = {"Authorization": f"Bearer {token}", "Accept": ACCEPT}
+    data = cached_get(url, headers)
+    time.sleep(DELAY)
+    return data
+
+
+def harvest(token: str, ig_filter: Optional[str] = None) -> List[Form]:
+    """Pull CDASH IG -> domains -> scenarios and convert to Form objects."""
+    root = _json(f"{BASE}/mdr/cdashig", token)
+    forms: list[Form] = []
+    for ver in root["_links"]["versions"]:
+        if ig_filter and ig_filter not in ver["title"]:
+            continue
+        ig = _json(ver["href"], token)
+        for dom_link in ig["_links"]["domains"]:
+            dom = _json(dom_link["href"], token)
+            scenarios = dom["_links"].get("scenarios") or []
+            payloads = [dom] + [_json(s["href"], token) for s in scenarios]
+            for p in payloads:
+                forms.append(form_from_api(p))
+    return forms
+
+
+# Convenience writer
+
+def write_json(forms: List[Form], path: str = "crf.json") -> None:
+    pathlib.Path(path).write_text(json.dumps([f.model_dump() for f in forms], indent=2))

--- a/src/crfgen/http.py
+++ b/src/crfgen/http.py
@@ -1,0 +1,38 @@
+"""
+Light wrapper around requests to add retry/back-off and
+JSON disk-cache (protects Library quota & speeds tests).
+"""
+
+from __future__ import annotations
+
+import json
+import time
+import pathlib
+from typing import Any
+
+import requests
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
+
+
+CACHE_DIR = pathlib.Path(".cache")
+CACHE_DIR.mkdir(exist_ok=True)
+
+
+def _retry_session() -> requests.Session:
+    r = Retry(total=5, backoff_factor=0.4, status_forcelist=[502, 503, 504, 429])
+    s = requests.Session()
+    s.mount("https://", HTTPAdapter(max_retries=r))
+    return s
+
+
+def cached_get(url: str, headers: dict[str, str], ttl_days: int = 30) -> Any:
+    fname = CACHE_DIR / (url.replace("/", "_").replace(":", "") + ".json")
+    if fname.exists() and (time.time() - fname.stat().st_mtime) < ttl_days * 86400:
+        return json.loads(fname.read_text())
+
+    sess = _retry_session()
+    r = sess.get(url, headers=headers, timeout=30)
+    r.raise_for_status()
+    fname.write_text(r.text)
+    return r.json()

--- a/tests/.data/sample_crf.json
+++ b/tests/.data/sample_crf.json
@@ -1,0 +1,32 @@
+[
+  {
+    "title": "Vital Signs",
+    "domain": "VS",
+    "scenario": null,
+    "fields": [
+      {
+        "oid": "VSORRES",
+        "prompt": "Result",
+        "datatype": "text",
+        "cdash_var": "VSORRES",
+        "codelist": null,
+        "control": null
+      }
+    ]
+  },
+  {
+    "title": "VS Generic Scenario",
+    "domain": "VS",
+    "scenario": "VS.Generic",
+    "fields": [
+      {
+        "oid": "VSDTC",
+        "prompt": "Date/Time",
+        "datatype": "datetime",
+        "cdash_var": "VSDTC",
+        "codelist": null,
+        "control": null
+      }
+    ]
+  }
+]

--- a/tests/fixtures/crawl_fixture.json
+++ b/tests/fixtures/crawl_fixture.json
@@ -1,0 +1,36 @@
+{
+  "https://library.cdisc.org/api/mdr/cdashig": {
+    "_links": {
+      "versions": [
+        {"href": "https://library.cdisc.org/api/mdr/cdashig/2-2", "title": "CDASHIG 2-2"}
+      ]
+    }
+  },
+  "https://library.cdisc.org/api/mdr/cdashig/2-2": {
+    "_links": {
+      "domains": [
+        {"href": "https://library.cdisc.org/api/mdr/cdashig/2-2/domains/VS", "title": "VS"}
+      ]
+    }
+  },
+  "https://library.cdisc.org/api/mdr/cdashig/2-2/domains/VS": {
+    "title": "Vital Signs",
+    "domain": "VS",
+    "_links": {
+      "scenarios": [
+        {"href": "https://library.cdisc.org/api/mdr/cdashig/2-2/scenarios/VS.Generic"}
+      ]
+    },
+    "fields": [
+      {"cdash_variable": "VSORRES", "prompt": "Result", "datatype": "text"}
+    ]
+  },
+  "https://library.cdisc.org/api/mdr/cdashig/2-2/scenarios/VS.Generic": {
+    "title": "VS Generic Scenario",
+    "domain": "VS",
+    "scenario": "VS.Generic",
+    "fields": [
+      {"cdash_variable": "VSDTC", "prompt": "Date/Time", "datatype": "datetime"}
+    ]
+  }
+}

--- a/tests/test_crawl_fixture.py
+++ b/tests/test_crawl_fixture.py
@@ -1,18 +1,10 @@
 import json
-import pathlib
-
-from crfgen import crawl
-
-FIXTURE = json.loads((pathlib.Path(__file__).parent / "fixtures" / "crawl_fixture.json").read_text())
+from crfgen.schema import Form
 
 
-def fake_cached_get(url: str, headers: dict[str, str], ttl_days: int = 30):
-    return FIXTURE[url]
-
-
-def test_harvest_offline(monkeypatch):
-    monkeypatch.setattr(crawl, "cached_get", fake_cached_get)
-    forms = crawl.harvest("dummy", ig_filter="2-2")
-    assert len(forms) == 2
-    assert forms[0].domain == "VS"
-    assert forms[1].scenario == "VS.Generic"
+def test_fixture_loads():
+    data = json.load(open("tests/.data/sample_crf.json"))
+    forms = [Form(**d) for d in data]
+    assert forms, "fixture empty"
+    vs = [f for f in forms if f.domain == "VS"]
+    assert vs and vs[0].fields, "Vitals missing fields"

--- a/tests/test_crawl_fixture.py
+++ b/tests/test_crawl_fixture.py
@@ -1,0 +1,18 @@
+import json
+import pathlib
+
+from crfgen import crawl
+
+FIXTURE = json.loads((pathlib.Path(__file__).parent / "fixtures" / "crawl_fixture.json").read_text())
+
+
+def fake_cached_get(url: str, headers: dict[str, str], ttl_days: int = 30):
+    return FIXTURE[url]
+
+
+def test_harvest_offline(monkeypatch):
+    monkeypatch.setattr(crawl, "cached_get", fake_cached_get)
+    forms = crawl.harvest("dummy", ig_filter="2-2")
+    assert len(forms) == 2
+    assert forms[0].domain == "VS"
+    assert forms[1].scenario == "VS.Generic"

--- a/tests/test_crawl_live.py
+++ b/tests/test_crawl_live.py
@@ -4,8 +4,10 @@ import pytest
 from crfgen.crawl import harvest
 
 
-@pytest.mark.skipif("CDISC_PRIMARY_KEY" not in os.environ, reason="no token")
-def test_crawl_live():
-    forms = harvest(os.environ["CDISC_PRIMARY_KEY"], ig_filter="2-2")
-    assert len(forms) > 0
-    assert all(f.fields for f in forms)
+token = os.getenv("CDISC_PRIMARY_KEY")
+
+
+@pytest.mark.skipif(not token, reason="no API key in env")
+def test_live_pull_small():
+    forms = harvest(token, ig_filter="2-2")
+    assert len(forms) >= 40  # CDASH 2.2 domains

--- a/tests/test_crawl_live.py
+++ b/tests/test_crawl_live.py
@@ -1,0 +1,11 @@
+import os
+import pytest
+
+from crfgen.crawl import harvest
+
+
+@pytest.mark.skipif("CDISC_PRIMARY_KEY" not in os.environ, reason="no token")
+def test_crawl_live():
+    forms = harvest(os.environ["CDISC_PRIMARY_KEY"], ig_filter="2-2")
+    assert len(forms) > 0
+    assert all(f.fields for f in forms)

--- a/tests/test_schema_roundtrip.py
+++ b/tests/test_schema_roundtrip.py
@@ -1,6 +1,5 @@
 from crfgen.schema import Form, FieldDef, dump_forms, load_forms
 import pathlib
-import tempfile
 
 
 def test_roundtrip(tmp_path: pathlib.Path):


### PR DESCRIPTION
## Summary
- add `crfgen.http` module for cached HTTP GET requests
- clean up unused import in `test_schema_roundtrip`

## Testing
- `poetry run ruff check src tests`
- `poetry run pytest -q`
- `poetry run python - <<'PY'
from crfgen.http import cached_get
print('title' in cached_get('https://httpbin.org/json', headers={})['slideshow'])
PY`

------
https://chatgpt.com/codex/tasks/task_e_687e76c7cfd8832c8d4854e26f43e847