### PR TITLE
Add artefact directory and packaging settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,5 @@ build/
 .venv/
 .cache/
 artefacts/
+!artefacts/.gitkeep
 .env

--- a/README.md
+++ b/README.md
@@ -23,6 +23,12 @@ exporter:
 python scripts/build.py --source tests/.data/sample_crf.json --outdir artefacts --formats docx
 ```
 
+CSV and Excel exports are also available:
+
+```bash
+python scripts/build.py --source tests/.data/sample_crf.json --outdir artefacts --formats csv xlsx
+```
+
 The command will create one file per form in the given output directory.
 
 Additional documentation is available in the [docs](docs/) directory, including an [FAQ](docs/FAQ.md) about accessing and using the CDISC Library.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,13 @@ Use the `scripts/build.py` helper to generate files in various formats. For exam
 python scripts/build.py --source tests/.data/sample_crf.json --outdir artefacts --formats md
 ```
 
-The command will create one Markdown file per form in the given output directory.
+To create LaTeX output instead, use `tex` as the format:
+
+```bash
+python scripts/build.py --source tests/.data/sample_crf.json --outdir artefacts --formats tex
+```
+
+The command will create one file per form in the given output directory.
 
 Additional documentation is available in the [docs](docs/) directory, including an [FAQ](docs/FAQ.md) about accessing and using the CDISC Library.
 

--- a/README.md
+++ b/README.md
@@ -2,5 +2,15 @@
 
 This project provides tools for generating Case Report Forms (CRFs) using metadata from the CDISC Library.
 
+## Exporting artefacts
+
+Use the `scripts/build.py` helper to generate files in various formats. For example, to create Markdown output:
+
+```bash
+python scripts/build.py --source tests/.data/sample_crf.json --outdir artefacts --formats md
+```
+
+The command will create one Markdown file per form in the given output directory.
+
 Additional documentation is available in the [docs](docs/) directory, including an [FAQ](docs/FAQ.md) about accessing and using the CDISC Library.
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,13 @@ To create LaTeX output instead, use `tex` as the format:
 python scripts/build.py --source tests/.data/sample_crf.json --outdir artefacts --formats tex
 ```
 
+To generate Word documents without relying on Pandoc, use the built in `docx`
+exporter:
+
+```bash
+python scripts/build.py --source tests/.data/sample_crf.json --outdir artefacts --formats docx
+```
+
 The command will create one file per form in the given output directory.
 
 Additional documentation is available in the [docs](docs/) directory, including an [FAQ](docs/FAQ.md) about accessing and using the CDISC Library.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,9 @@ packages = [
     { from = "src", include = "crfgen" }
 ]
 
+[tool.poetry.package]
+include = ["src/crfgen/templates/*.j2", "src/crfgen/style/*"]
+
 [tool.poetry.dependencies]
 python = ">=3.11,<4.0"
 openapi-python-client = "^0.25"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,8 @@ packages = [
     { from = "src", include = "crfgen" }
 ]
 
-[tool.poetry.package]
+
+
 include = ["src/crfgen/templates/*.j2", "src/crfgen/style/*"]
 
 [tool.poetry.dependencies]

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -4,12 +4,23 @@ import argparse
 import importlib
 from pathlib import Path
 
+import crfgen.exporter.markdown   # noqa
+import crfgen.exporter.latex      # noqa
+import crfgen.exporter.docx       # noqa
+import crfgen.exporter.csv        # noqa
+import crfgen.exporter.xlsx       # noqa
+import crfgen.exporter.odm        # noqa
+
 from crfgen.schema import load_forms
 from crfgen.exporter import EXPORTERS
 
 MODULE_MAP = {
     "md": "markdown",
     "tex": "latex",
+    "docx": "docx",
+    "csv": "csv",
+    "xlsx": "xlsx",
+    "odm": "odm",
 }
 
 

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -9,6 +9,7 @@ from crfgen.exporter import EXPORTERS
 
 MODULE_MAP = {
     "md": "markdown",
+    "tex": "latex",
 }
 
 

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python
+"""Generate artefacts in various formats from a CRF JSON file."""
+import argparse
+import importlib
+from pathlib import Path
+
+from crfgen.schema import load_forms
+from crfgen.exporter import EXPORTERS
+
+MODULE_MAP = {
+    "md": "markdown",
+}
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description="Build CRF artefacts")
+    p.add_argument("--source", required=True, help="Path to forms JSON")
+    p.add_argument("--outdir", required=True, help="Directory for output files")
+    p.add_argument("--formats", nargs="+", required=True, help="Output formats")
+    args = p.parse_args()
+
+    forms = load_forms(args.source)
+    out_dir = Path(args.outdir)
+
+    for fmt in args.formats:
+        # attempt to import exporter module dynamically
+        mod_name = MODULE_MAP.get(fmt, fmt)
+        try:
+            importlib.import_module(f"crfgen.exporter.{mod_name}")
+        except ModuleNotFoundError:
+            pass
+        exporter = EXPORTERS.get(fmt)
+        if not exporter:
+            raise SystemExit(f"Unknown format: {fmt}")
+        exporter(forms, out_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/crfgen/exporter/__init__.py
+++ b/src/crfgen/exporter/__init__.py
@@ -1,0 +1,3 @@
+from .registry import EXPORTERS, register
+
+__all__ = ["EXPORTERS", "register"]

--- a/src/crfgen/exporter/csv.py
+++ b/src/crfgen/exporter/csv.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+from pathlib import Path
+from typing import List
+import pandas as pd
+
+from ..schema import Form
+from .registry import register
+
+
+@register("csv")
+def render_csv(forms: List[Form], out_dir: Path) -> None:
+    """Write all forms to a single CSV file."""
+    rows = []
+    for form in forms:
+        for fld in form.fields:
+            rows.append(
+                {
+                    "form": form.title,
+                    "domain": form.domain,
+                    "scenario": form.scenario or "",
+                    "oid": fld.oid,
+                    "prompt": fld.prompt,
+                    "datatype": fld.datatype,
+                    "codelist": fld.codelist.nci_code if fld.codelist else "",
+                }
+            )
+    out_dir.mkdir(parents=True, exist_ok=True)
+    pd.DataFrame(rows).to_csv(out_dir / "forms.csv", index=False)

--- a/src/crfgen/exporter/docx.py
+++ b/src/crfgen/exporter/docx.py
@@ -1,0 +1,35 @@
+from pathlib import Path
+from typing import List
+
+from docx import Document
+
+from ..schema import Form
+from .registry import register
+
+
+@register("docx")
+def render_docx(forms: List[Form], out_dir: Path):
+    """Render forms as simple DOCX files."""
+    out_dir.mkdir(parents=True, exist_ok=True)
+    for f in forms:
+        doc = Document()
+        title = f.title
+        if f.scenario:
+            title += f" ({f.scenario})"
+        doc.add_heading(title, level=1)
+
+        table = doc.add_table(rows=1, cols=4)
+        hdr_cells = table.rows[0].cells
+        hdr_cells[0].text = "OID"
+        hdr_cells[1].text = "Prompt"
+        hdr_cells[2].text = "Datatype"
+        hdr_cells[3].text = "Codelist"
+
+        for fld in f.fields:
+            row = table.add_row().cells
+            row[0].text = fld.oid
+            row[1].text = fld.prompt
+            row[2].text = fld.datatype
+            row[3].text = fld.codelist.nci_code if fld.codelist else ""
+
+        doc.save(out_dir / f"{f.domain}.docx")

--- a/src/crfgen/exporter/latex.py
+++ b/src/crfgen/exporter/latex.py
@@ -1,0 +1,14 @@
+from pathlib import Path
+from typing import List
+from jinja2 import Environment, FileSystemLoader
+from ..schema import Form
+from .registry import register
+
+env = Environment(loader=FileSystemLoader(Path(__file__).parent.parent / "templates"))
+
+@register("tex")
+def render_tex(forms: List[Form], out_dir: Path):
+    out_dir.mkdir(exist_ok=True, parents=True)
+    tpl = env.get_template("latex.j2")
+    for f in forms:
+        (out_dir / f"{f.domain}.tex").write_text(tpl.render(form=f))

--- a/src/crfgen/exporter/markdown.py
+++ b/src/crfgen/exporter/markdown.py
@@ -1,0 +1,17 @@
+from pathlib import Path
+from typing import List
+from jinja2 import Environment, FileSystemLoader, select_autoescape
+from ..schema import Form
+from .registry import register
+
+env = Environment(
+    loader=FileSystemLoader(Path(__file__).parent.parent / "templates"),
+    autoescape=select_autoescape()
+)
+
+@register("md")
+def render_md(forms: List[Form], out_dir: Path):
+    tpl = env.get_template("markdown.j2")
+    out_dir.mkdir(parents=True, exist_ok=True)
+    for f in forms:
+        (out_dir / f"{f.domain}.md").write_text(tpl.render(form=f))

--- a/src/crfgen/exporter/odm.py
+++ b/src/crfgen/exporter/odm.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+from typing import List
+import xml.etree.ElementTree as ET
+from xml.dom import minidom
+
+from ..schema import Form
+from .registry import register
+
+
+@register("odm")
+def render_odm(forms: List[Form], out_dir: Path):
+    odm = ET.Element("ODM", Description="Generated CRFs")
+    study = ET.SubElement(odm, "Study", OID="ST.CRFGEN")
+    mdv = ET.SubElement(study, "MetaDataVersion", OID="MDV.1")
+    for f in forms:
+        ET.SubElement(mdv, "FormDef", OID=f"F.{f.domain}", Name=f.title)
+    out_dir.mkdir(exist_ok=True, parents=True)
+    xml_str = ET.tostring(odm, encoding="utf-8")
+    pretty = minidom.parseString(xml_str).toprettyxml(indent="  ")
+    (out_dir / "forms.odm.xml").write_text(pretty)

--- a/src/crfgen/exporter/registry.py
+++ b/src/crfgen/exporter/registry.py
@@ -7,6 +7,11 @@ from ..schema import Form
 EXPORTERS: Dict[str, Callable[[List[Form], Path], None]] = {}
 
 
+def get(name: str) -> Callable[[List[Form], Path], None]:
+    """Retrieve a registered exporter by name."""
+    return EXPORTERS[name]
+
+
 def register(name: str) -> Callable[[Callable[[List[Form], Path], None]], Callable[[List[Form], Path], None]]:
     """Decorator to register an exporter function."""
 

--- a/src/crfgen/exporter/registry.py
+++ b/src/crfgen/exporter/registry.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+from typing import Callable, Dict, List
+from pathlib import Path
+
+from ..schema import Form
+
+EXPORTERS: Dict[str, Callable[[List[Form], Path], None]] = {}
+
+
+def register(name: str) -> Callable[[Callable[[List[Form], Path], None]], Callable[[List[Form], Path], None]]:
+    """Decorator to register an exporter function."""
+
+    def decorator(func: Callable[[List[Form], Path], None]) -> Callable[[List[Form], Path], None]:
+        EXPORTERS[name] = func
+        return func
+
+    return decorator

--- a/src/crfgen/exporter/xlsx.py
+++ b/src/crfgen/exporter/xlsx.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+from pathlib import Path
+from typing import List
+import pandas as pd
+
+from ..schema import Form
+from .registry import register
+
+
+@register("xlsx")
+def render_xlsx(forms: List[Form], out_dir: Path) -> None:
+    """Write all forms to a single Excel workbook."""
+    rows = []
+    for form in forms:
+        for fld in form.fields:
+            rows.append(
+                {
+                    "form": form.title,
+                    "domain": form.domain,
+                    "scenario": form.scenario or "",
+                    "oid": fld.oid,
+                    "prompt": fld.prompt,
+                    "datatype": fld.datatype,
+                    "codelist": fld.codelist.nci_code if fld.codelist else "",
+                }
+            )
+    out_dir.mkdir(parents=True, exist_ok=True)
+    pd.DataFrame(rows).to_excel(out_dir / "forms.xlsx", index=False)

--- a/src/crfgen/templates/latex.j2
+++ b/src/crfgen/templates/latex.j2
@@ -1,0 +1,7 @@
+\section*{ {{ form.title }}{% if form.scenario %} ({{ form.scenario }}){% endif %} }
+\begin{tabular}{llll}
+\textbf{OID} & \textbf{Prompt} & \textbf{Datatype} & \textbf{Codelist}\\ \hline
+{% for fld in form.fields -%}
+{{ fld.oid }} & {{ fld.prompt|replace('&','\\&') }} & {{ fld.datatype }} & {% if fld.codelist %}{{ fld.codelist.nci_code }}{% endif %} \\
+{% endfor %}
+\end{tabular}

--- a/src/crfgen/templates/markdown.j2
+++ b/src/crfgen/templates/markdown.j2
@@ -1,0 +1,7 @@
+# {{ form.title }}{% if form.scenario %} ({{ form.scenario }}){% endif %}
+
+| OID | Prompt | Datatype | Codelist |
+|-----|--------|----------|----------|
+{% for fld in form.fields -%}
+| `{{ fld.oid }}` | {{ fld.prompt|replace('|','\\|') }} | {{ fld.datatype }} | {% if fld.codelist %}{{ fld.codelist.nci_code }}{% endif %} |
+{% endfor %}

--- a/tests/test_docx_exporter.py
+++ b/tests/test_docx_exporter.py
@@ -1,0 +1,36 @@
+import os
+import subprocess
+from pathlib import Path
+from docx import Document
+
+from crfgen.schema import load_forms
+from crfgen.exporter import EXPORTERS
+import crfgen.exporter.docx  # register docx exporter
+
+
+def test_render_docx(tmp_path: Path):
+    forms = load_forms("tests/.data/sample_crf.json")
+    exporter = EXPORTERS["docx"]
+    exporter(forms, tmp_path)
+    files = list(tmp_path.glob("*.docx"))
+    assert files
+    doc = Document(files[0])
+    texts = [cell.text for row in doc.tables[0].rows for cell in row.cells]
+    assert "OID" in texts
+
+
+def test_build_script(tmp_path: Path):
+    cmd = [
+        "python",
+        "scripts/build.py",
+        "--source",
+        "tests/.data/sample_crf.json",
+        "--outdir",
+        str(tmp_path),
+        "--formats",
+        "docx",
+    ]
+    env = os.environ.copy()
+    env["PYTHONPATH"] = "src"
+    subprocess.check_call(cmd, env=env)
+    assert list(Path(tmp_path).glob("*.docx"))

--- a/tests/test_exporters.py
+++ b/tests/test_exporters.py
@@ -1,0 +1,21 @@
+import pathlib, json, tempfile
+from crfgen.schema import Form
+from crfgen.exporter import registry as reg
+import importlib
+
+# import exporters so they register
+for m in ("markdown","latex","csv"):
+    importlib.import_module(f"crfgen.exporter.{m}")
+
+forms = [Form(**json.load(open("tests/.data/sample_crf.json"))[0])]
+
+def _tmpdir():
+    return pathlib.Path(tempfile.mkdtemp())
+
+def test_md():
+    out=_tmpdir(); reg.get("md")(forms, out)
+    assert any(out.glob("*.md"))
+
+def test_csv():
+    out=_tmpdir(); reg.get("csv")(forms, out)
+    assert (out/"forms.csv").exists()

--- a/tests/test_latex_exporter.py
+++ b/tests/test_latex_exporter.py
@@ -1,0 +1,34 @@
+import os
+import subprocess
+from pathlib import Path
+
+from crfgen.schema import load_forms
+from crfgen.exporter import EXPORTERS
+import crfgen.exporter.latex  # register tex exporter
+
+
+def test_render_tex(tmp_path: Path):
+    forms = load_forms("tests/.data/sample_crf.json")
+    exporter = EXPORTERS["tex"]
+    exporter(forms, tmp_path)
+    files = list(tmp_path.glob("*.tex"))
+    assert files
+    txt = files[0].read_text()
+    assert "\\textbf{OID}" in txt
+
+
+def test_build_script(tmp_path: Path):
+    cmd = [
+        "python",
+        "scripts/build.py",
+        "--source",
+        "tests/.data/sample_crf.json",
+        "--outdir",
+        str(tmp_path),
+        "--formats",
+        "tex",
+    ]
+    env = os.environ.copy()
+    env["PYTHONPATH"] = "src"
+    subprocess.check_call(cmd, env=env)
+    assert list(Path(tmp_path).glob("*.tex"))

--- a/tests/test_markdown_exporter.py
+++ b/tests/test_markdown_exporter.py
@@ -1,0 +1,34 @@
+import os
+import subprocess
+from pathlib import Path
+
+from crfgen.schema import load_forms
+from crfgen.exporter import EXPORTERS
+import crfgen.exporter.markdown  # register md exporter
+
+
+def test_render_md(tmp_path: Path):
+    forms = load_forms("tests/.data/sample_crf.json")
+    exporter = EXPORTERS["md"]
+    exporter(forms, tmp_path)
+    files = list(tmp_path.glob("*.md"))
+    assert files
+    txt = files[0].read_text()
+    assert "| OID |" in txt
+
+
+def test_build_script(tmp_path: Path):
+    cmd = [
+        "python",
+        "scripts/build.py",
+        "--source",
+        "tests/.data/sample_crf.json",
+        "--outdir",
+        str(tmp_path),
+        "--formats",
+        "md",
+    ]
+    env = os.environ.copy()
+    env["PYTHONPATH"] = "src"
+    subprocess.check_call(cmd, env=env)
+    assert list(Path(tmp_path).glob("*.md"))

--- a/tests/test_odm_exporter.py
+++ b/tests/test_odm_exporter.py
@@ -1,0 +1,34 @@
+import os
+import subprocess
+from pathlib import Path
+
+from crfgen.schema import load_forms
+from crfgen.exporter import EXPORTERS
+import crfgen.exporter.odm  # register odm exporter
+
+
+def test_render_odm(tmp_path: Path):
+    forms = load_forms("tests/.data/sample_crf.json")
+    exporter = EXPORTERS["odm"]
+    exporter(forms, tmp_path)
+    file = tmp_path / "forms.odm.xml"
+    assert file.exists()
+    txt = file.read_text()
+    assert "<FormDef" in txt
+
+
+def test_build_script(tmp_path: Path):
+    cmd = [
+        "python",
+        "scripts/build.py",
+        "--source",
+        "tests/.data/sample_crf.json",
+        "--outdir",
+        str(tmp_path),
+        "--formats",
+        "odm",
+    ]
+    env = os.environ.copy()
+    env["PYTHONPATH"] = "src"
+    subprocess.check_call(cmd, env=env)
+    assert (tmp_path / "forms.odm.xml").exists()


### PR DESCRIPTION
## Summary
- create `artefacts` directory for exporter output
- package template and style files via Poetry
- track artefacts directory via `.gitkeep`

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e8f65b908832cb122676c0c964ae0