### PR TITLE
Add markdown exporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,5 +2,15 @@
 
 This project provides tools for generating Case Report Forms (CRFs) using metadata from the CDISC Library.
 
+## Exporting artefacts
+
+Use the `scripts/build.py` helper to generate files in various formats. For example, to create Markdown output:
+
+```bash
+python scripts/build.py --source tests/.data/sample_crf.json --outdir artefacts --formats md
+```
+
+The command will create one Markdown file per form in the given output directory.
+
 Additional documentation is available in the [docs](docs/) directory, including an [FAQ](docs/FAQ.md) about accessing and using the CDISC Library.
 

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python
+"""Generate artefacts in various formats from a CRF JSON file."""
+import argparse
+import importlib
+from pathlib import Path
+
+from crfgen.schema import load_forms
+from crfgen.exporter import EXPORTERS
+
+MODULE_MAP = {
+    "md": "markdown",
+}
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description="Build CRF artefacts")
+    p.add_argument("--source", required=True, help="Path to forms JSON")
+    p.add_argument("--outdir", required=True, help="Directory for output files")
+    p.add_argument("--formats", nargs="+", required=True, help="Output formats")
+    args = p.parse_args()
+
+    forms = load_forms(args.source)
+    out_dir = Path(args.outdir)
+
+    for fmt in args.formats:
+        # attempt to import exporter module dynamically
+        mod_name = MODULE_MAP.get(fmt, fmt)
+        try:
+            importlib.import_module(f"crfgen.exporter.{mod_name}")
+        except ModuleNotFoundError:
+            pass
+        exporter = EXPORTERS.get(fmt)
+        if not exporter:
+            raise SystemExit(f"Unknown format: {fmt}")
+        exporter(forms, out_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/crfgen/exporter/__init__.py
+++ b/src/crfgen/exporter/__init__.py
@@ -1,0 +1,3 @@
+from .registry import EXPORTERS, register
+
+__all__ = ["EXPORTERS", "register"]

--- a/src/crfgen/exporter/markdown.py
+++ b/src/crfgen/exporter/markdown.py
@@ -1,0 +1,17 @@
+from pathlib import Path
+from typing import List
+from jinja2 import Environment, FileSystemLoader, select_autoescape
+from ..schema import Form
+from .registry import register
+
+env = Environment(
+    loader=FileSystemLoader(Path(__file__).parent.parent / "templates"),
+    autoescape=select_autoescape()
+)
+
+@register("md")
+def render_md(forms: List[Form], out_dir: Path):
+    tpl = env.get_template("markdown.j2")
+    out_dir.mkdir(parents=True, exist_ok=True)
+    for f in forms:
+        (out_dir / f"{f.domain}.md").write_text(tpl.render(form=f))

--- a/src/crfgen/exporter/registry.py
+++ b/src/crfgen/exporter/registry.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+from typing import Callable, Dict, List
+from pathlib import Path
+
+from ..schema import Form
+
+EXPORTERS: Dict[str, Callable[[List[Form], Path], None]] = {}
+
+
+def register(name: str) -> Callable[[Callable[[List[Form], Path], None]], Callable[[List[Form], Path], None]]:
+    """Decorator to register an exporter function."""
+
+    def decorator(func: Callable[[List[Form], Path], None]) -> Callable[[List[Form], Path], None]:
+        EXPORTERS[name] = func
+        return func
+
+    return decorator

--- a/src/crfgen/templates/markdown.j2
+++ b/src/crfgen/templates/markdown.j2
@@ -1,0 +1,7 @@
+# {{ form.title }}{% if form.scenario %} ({{ form.scenario }}){% endif %}
+
+| OID | Prompt | Datatype | Codelist |
+|-----|--------|----------|----------|
+{% for fld in form.fields -%}
+| `{{ fld.oid }}` | {{ fld.prompt|replace('|','\\|') }} | {{ fld.datatype }} | {% if fld.codelist %}{{ fld.codelist.nci_code }}{% endif %} |
+{% endfor %}

--- a/tests/test_markdown_exporter.py
+++ b/tests/test_markdown_exporter.py
@@ -1,0 +1,34 @@
+import os
+import subprocess
+from pathlib import Path
+
+from crfgen.schema import load_forms
+from crfgen.exporter import EXPORTERS
+import crfgen.exporter.markdown  # register md exporter
+
+
+def test_render_md(tmp_path: Path):
+    forms = load_forms("tests/.data/sample_crf.json")
+    exporter = EXPORTERS["md"]
+    exporter(forms, tmp_path)
+    files = list(tmp_path.glob("*.md"))
+    assert files
+    txt = files[0].read_text()
+    assert "| OID |" in txt
+
+
+def test_build_script(tmp_path: Path):
+    cmd = [
+        "python",
+        "scripts/build.py",
+        "--source",
+        "tests/.data/sample_crf.json",
+        "--outdir",
+        str(tmp_path),
+        "--formats",
+        "md",
+    ]
+    env = os.environ.copy()
+    env["PYTHONPATH"] = "src"
+    subprocess.check_call(cmd, env=env)
+    assert list(Path(tmp_path).glob("*.md"))


### PR DESCRIPTION
## Summary
- implement Markdown template under `src/crfgen/templates`
- create exporter registry and markdown exporter
- add build helper script to generate artefacts
- include new exporter package

## Testing
- `PYTHONPATH=src python scripts/build.py --source tests/.data/sample_crf.json --outdir artefacts --formats md`
- `ls artefacts/*.md | head`
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687e903187d0832ca23638652facf585