### PR TITLE
Add LaTeX exporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,13 @@ Use the `scripts/build.py` helper to generate files in various formats. For exam
 python scripts/build.py --source tests/.data/sample_crf.json --outdir artefacts --formats md
 ```
 
-The command will create one Markdown file per form in the given output directory.
+To create LaTeX output instead, use `tex` as the format:
+
+```bash
+python scripts/build.py --source tests/.data/sample_crf.json --outdir artefacts --formats tex
+```
+
+The command will create one file per form in the given output directory.
 
 Additional documentation is available in the [docs](docs/) directory, including an [FAQ](docs/FAQ.md) about accessing and using the CDISC Library.
 

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -9,6 +9,7 @@ from crfgen.exporter import EXPORTERS
 
 MODULE_MAP = {
     "md": "markdown",
+    "tex": "latex",
 }
 
 

--- a/src/crfgen/exporter/latex.py
+++ b/src/crfgen/exporter/latex.py
@@ -1,0 +1,14 @@
+from pathlib import Path
+from typing import List
+from jinja2 import Environment, FileSystemLoader
+from ..schema import Form
+from .registry import register
+
+env = Environment(loader=FileSystemLoader(Path(__file__).parent.parent / "templates"))
+
+@register("tex")
+def render_tex(forms: List[Form], out_dir: Path):
+    out_dir.mkdir(exist_ok=True, parents=True)
+    tpl = env.get_template("latex.j2")
+    for f in forms:
+        (out_dir / f"{f.domain}.tex").write_text(tpl.render(form=f))

--- a/src/crfgen/templates/latex.j2
+++ b/src/crfgen/templates/latex.j2
@@ -1,0 +1,7 @@
+\section*{ {{ form.title }}{% if form.scenario %} ({{ form.scenario }}){% endif %} }
+\begin{tabular}{llll}
+\textbf{OID} & \textbf{Prompt} & \textbf{Datatype} & \textbf{Codelist}\\ \hline
+{% for fld in form.fields -%}
+{{ fld.oid }} & {{ fld.prompt|replace('&','\\&') }} & {{ fld.datatype }} & {% if fld.codelist %}{{ fld.codelist.nci_code }}{% endif %} \\
+{% endfor %}
+\end{tabular}

--- a/tests/test_latex_exporter.py
+++ b/tests/test_latex_exporter.py
@@ -1,0 +1,34 @@
+import os
+import subprocess
+from pathlib import Path
+
+from crfgen.schema import load_forms
+from crfgen.exporter import EXPORTERS
+import crfgen.exporter.latex  # register tex exporter
+
+
+def test_render_tex(tmp_path: Path):
+    forms = load_forms("tests/.data/sample_crf.json")
+    exporter = EXPORTERS["tex"]
+    exporter(forms, tmp_path)
+    files = list(tmp_path.glob("*.tex"))
+    assert files
+    txt = files[0].read_text()
+    assert "\\textbf{OID}" in txt
+
+
+def test_build_script(tmp_path: Path):
+    cmd = [
+        "python",
+        "scripts/build.py",
+        "--source",
+        "tests/.data/sample_crf.json",
+        "--outdir",
+        str(tmp_path),
+        "--formats",
+        "tex",
+    ]
+    env = os.environ.copy()
+    env["PYTHONPATH"] = "src"
+    subprocess.check_call(cmd, env=env)
+    assert list(Path(tmp_path).glob("*.tex"))


### PR DESCRIPTION
## Summary
- add LaTeX exporter and template
- support `tex` format in `scripts/build.py`
- document LaTeX option in README
- test rendering to LaTeX

## Testing
- `PYTHONPATH=src pytest -q`
- `PYTHONPATH=src python scripts/build.py --source tests/.data/sample_crf.json --outdir artefacts --formats tex`
- `ls artefacts/*.tex | head`

------
https://chatgpt.com/codex/tasks/task_e_687e93cd7dc8832c967ccd8370609d46