### PR TITLE
Add XLSX exporter

### DIFF
--- a/src/crfgen/exporter/xlsx.py
+++ b/src/crfgen/exporter/xlsx.py
@@ -1,0 +1,25 @@
+import pandas as pd
+from pathlib import Path
+from typing import List
+from ..schema import Form
+from .registry import register
+
+
+@register("xlsx")
+def render_xlsx(forms: List[Form], out_dir: Path):
+    out_dir.mkdir(exist_ok=True, parents=True)
+    with pd.ExcelWriter(out_dir / "forms.xlsx") as xw:
+        for f in forms:
+            df = pd.DataFrame(
+                [
+                    {
+                        "OID": fld.oid,
+                        "Prompt": fld.prompt,
+                        "Datatype": fld.datatype,
+                        "Codelist": fld.codelist.nci_code if fld.codelist else "",
+                    }
+                    for fld in f.fields
+                ]
+            )
+            sheet = f"{f.domain[:28]}{('-'+f.scenario) if f.scenario else ''}"[:31]
+            df.to_excel(xw, sheet_name=sheet or f.domain, index=False)

--- a/tests/test_xlsx_exporter.py
+++ b/tests/test_xlsx_exporter.py
@@ -1,0 +1,39 @@
+import os
+import subprocess
+from pathlib import Path
+
+from crfgen.schema import load_forms
+from crfgen.exporter import EXPORTERS
+import crfgen.exporter.xlsx  # register xlsx exporter
+
+
+def test_render_xlsx(tmp_path: Path):
+    forms = load_forms("tests/.data/sample_crf.json")
+    exporter = EXPORTERS["xlsx"]
+    exporter(forms, tmp_path)
+    xlsx_file = tmp_path / "forms.xlsx"
+    assert xlsx_file.exists()
+    import openpyxl
+
+    wb = openpyxl.load_workbook(xlsx_file)
+    assert wb.sheetnames
+    sheet = wb[wb.sheetnames[0]]
+    header = [cell.value for cell in next(sheet.iter_rows(values_only=False))]
+    assert header[:4] == ["OID", "Prompt", "Datatype", "Codelist"]
+
+
+def test_build_script(tmp_path: Path):
+    cmd = [
+        "python",
+        "scripts/build.py",
+        "--source",
+        "tests/.data/sample_crf.json",
+        "--outdir",
+        str(tmp_path),
+        "--formats",
+        "xlsx",
+    ]
+    env = os.environ.copy()
+    env["PYTHONPATH"] = "src"
+    subprocess.check_call(cmd, env=env)
+    assert (Path(tmp_path) / "forms.xlsx").exists()


### PR DESCRIPTION
## Summary
- implement XLSX exporter for CRF forms
- test xlsx exporter and build script

## Testing
- `pytest -q`
- `python - <<'PY'
import openpyxl
wb=openpyxl.load_workbook('artefacts/forms.xlsx')
print('Sheets:', wb.sheetnames[:3])
PY`

------
https://chatgpt.com/codex/tasks/task_e_687eb8d8e6d4832cbba947f9ea0e9095