### PR TITLE
Add DOCX exporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,13 @@ To create LaTeX output instead, use `tex` as the format:
 python scripts/build.py --source tests/.data/sample_crf.json --outdir artefacts --formats tex
 ```
 
+To generate Word documents without relying on Pandoc, use the built in `docx`
+exporter:
+
+```bash
+python scripts/build.py --source tests/.data/sample_crf.json --outdir artefacts --formats docx
+```
+
 The command will create one file per form in the given output directory.
 
 Additional documentation is available in the [docs](docs/) directory, including an [FAQ](docs/FAQ.md) about accessing and using the CDISC Library.

--- a/src/crfgen/exporter/docx.py
+++ b/src/crfgen/exporter/docx.py
@@ -1,0 +1,35 @@
+from pathlib import Path
+from typing import List
+
+from docx import Document
+
+from ..schema import Form
+from .registry import register
+
+
+@register("docx")
+def render_docx(forms: List[Form], out_dir: Path):
+    """Render forms as simple DOCX files."""
+    out_dir.mkdir(parents=True, exist_ok=True)
+    for f in forms:
+        doc = Document()
+        title = f.title
+        if f.scenario:
+            title += f" ({f.scenario})"
+        doc.add_heading(title, level=1)
+
+        table = doc.add_table(rows=1, cols=4)
+        hdr_cells = table.rows[0].cells
+        hdr_cells[0].text = "OID"
+        hdr_cells[1].text = "Prompt"
+        hdr_cells[2].text = "Datatype"
+        hdr_cells[3].text = "Codelist"
+
+        for fld in f.fields:
+            row = table.add_row().cells
+            row[0].text = fld.oid
+            row[1].text = fld.prompt
+            row[2].text = fld.datatype
+            row[3].text = fld.codelist.nci_code if fld.codelist else ""
+
+        doc.save(out_dir / f"{f.domain}.docx")

--- a/tests/test_docx_exporter.py
+++ b/tests/test_docx_exporter.py
@@ -1,0 +1,36 @@
+import os
+import subprocess
+from pathlib import Path
+from docx import Document
+
+from crfgen.schema import load_forms
+from crfgen.exporter import EXPORTERS
+import crfgen.exporter.docx  # register docx exporter
+
+
+def test_render_docx(tmp_path: Path):
+    forms = load_forms("tests/.data/sample_crf.json")
+    exporter = EXPORTERS["docx"]
+    exporter(forms, tmp_path)
+    files = list(tmp_path.glob("*.docx"))
+    assert files
+    doc = Document(files[0])
+    texts = [cell.text for row in doc.tables[0].rows for cell in row.cells]
+    assert "OID" in texts
+
+
+def test_build_script(tmp_path: Path):
+    cmd = [
+        "python",
+        "scripts/build.py",
+        "--source",
+        "tests/.data/sample_crf.json",
+        "--outdir",
+        str(tmp_path),
+        "--formats",
+        "docx",
+    ]
+    env = os.environ.copy()
+    env["PYTHONPATH"] = "src"
+    subprocess.check_call(cmd, env=env)
+    assert list(Path(tmp_path).glob("*.docx"))


### PR DESCRIPTION
## Summary
- support Microsoft Word output
- document DOCX build instructions
- test DOCX exporter

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ed5187630832ca030896a54dff563