### PR TITLE
Add build dispatcher CLI and exporter stubs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - uses: abatilo/actions-poetry@v2
+        with:
+          poetry-version: '1.7.1'
+      - name: Install dependencies
+        run: poetry install -n
+      - name: Build canonical JSON
+        env:
+          CDISC_PRIMARY_KEY: ${{ secrets.CDISC_PRIMARY_KEY }}
+        run: poetry run scripts/build_canonical.py
+      - name: Build all formats
+        run: |
+          poetry run scripts/build.py --source crf.json --outdir artefacts
+      - name: Run tests
+        run: poetry run pytest -q
+      - name: Upload artefacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: artefacts
+          path: artefacts

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""
+Dispatch to each exporter to generate all formats from crf.json.
+"""
+import sys
+import json
+from pathlib import Path
+
+from crfgen.schema import Form
+from crfgen.exporter import registry as reg
+
+# Import exporters to register them
+import crfgen.exporter.markdown  # noqa
+import crfgen.exporter.latex  # noqa
+import crfgen.exporter.docx  # noqa
+import crfgen.exporter.csv  # noqa
+import crfgen.exporter.xlsx  # noqa
+import crfgen.exporter.odm  # noqa
+
+
+def main() -> None:
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--source",
+        "-s",
+        default="crf.json",
+        help="Path to the canonical JSON",
+    )
+    parser.add_argument(
+        "--outdir",
+        "-o",
+        default="artefacts",
+        help="Directory to emit artifacts",
+    )
+    parser.add_argument(
+        "--formats",
+        "-f",
+        nargs="+",
+        default=reg.formats(),
+        help="Which formats to generate",
+    )
+    args = parser.parse_args()
+
+    src = Path(args.source)
+    if not src.exists():
+        sys.exit(f"ERROR: source file not found: {src}")
+
+    with src.open() as fp:
+        data = json.load(fp)
+    forms = [Form(**d) for d in data]
+
+    outdir = Path(args.outdir)
+    outdir.mkdir(parents=True, exist_ok=True)
+
+    for fmt in args.formats:
+        fn = reg.get(fmt)
+        print(f"[build] Rendering {fmt} → {outdir}")
+        fn(forms, outdir)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/crfgen/exporter/__init__.py
+++ b/src/crfgen/exporter/__init__.py
@@ -1,0 +1,5 @@
+"""Exporters for various output formats."""
+
+from .registry import register, get, formats
+
+__all__ = ["register", "get", "formats"]

--- a/src/crfgen/exporter/csv.py
+++ b/src/crfgen/exporter/csv.py
@@ -1,0 +1,18 @@
+from pathlib import Path
+from typing import Sequence
+import csv
+
+from crfgen.schema import Form
+from .registry import register
+
+
+@register("csv")
+def export_csv(forms: Sequence[Form], outdir: Path) -> None:
+    path = outdir / "forms.csv"
+    with path.open("w", newline="") as fh:
+        writer = csv.writer(fh)
+        writer.writerow(["domain", "oid", "prompt"])
+        for form in forms:
+            for fld in form.fields:
+                writer.writerow([form.domain, fld.oid, fld.prompt])
+

--- a/src/crfgen/exporter/docx.py
+++ b/src/crfgen/exporter/docx.py
@@ -1,0 +1,17 @@
+from pathlib import Path
+from typing import Sequence
+import docx
+
+from crfgen.schema import Form
+from .registry import register
+
+
+@register("docx")
+def export_docx(forms: Sequence[Form], outdir: Path) -> None:
+    doc = docx.Document()
+    for form in forms:
+        doc.add_heading(form.title, level=1)
+        for fld in form.fields:
+            doc.add_paragraph(f"{fld.prompt} ({fld.oid})")
+    doc.save(outdir / "forms.docx")
+

--- a/src/crfgen/exporter/latex.py
+++ b/src/crfgen/exporter/latex.py
@@ -1,0 +1,16 @@
+from pathlib import Path
+from typing import Sequence
+
+from crfgen.schema import Form
+from .registry import register
+
+
+@register("tex")
+def export_latex(forms: Sequence[Form], outdir: Path) -> None:
+    for form in forms:
+        path = outdir / f"{form.domain}.tex"
+        with path.open("w") as fh:
+            fh.write(f"\\section{{{form.title}}}\n")
+            for fld in form.fields:
+                fh.write(f"\\item {fld.prompt} ({fld.oid})\n")
+

--- a/src/crfgen/exporter/markdown.py
+++ b/src/crfgen/exporter/markdown.py
@@ -1,0 +1,16 @@
+from pathlib import Path
+from typing import Sequence
+
+from crfgen.schema import Form
+from .registry import register
+
+
+@register("md")
+def export_markdown(forms: Sequence[Form], outdir: Path) -> None:
+    for form in forms:
+        path = outdir / f"{form.domain}.md"
+        with path.open("w") as fh:
+            fh.write(f"# {form.title}\n")
+            for fld in form.fields:
+                fh.write(f"- {fld.prompt} ({fld.oid})\n")
+

--- a/src/crfgen/exporter/odm.py
+++ b/src/crfgen/exporter/odm.py
@@ -1,0 +1,18 @@
+from pathlib import Path
+from typing import Sequence
+import xml.etree.ElementTree as ET
+
+from crfgen.schema import Form
+from .registry import register
+
+
+@register("odm")
+def export_odm(forms: Sequence[Form], outdir: Path) -> None:
+    root = ET.Element("ODM")
+    for form in forms:
+        form_el = ET.SubElement(root, "FormDef", OID=form.domain, Name=form.title)
+        for fld in form.fields:
+            ET.SubElement(form_el, "ItemRef", OID=fld.oid)
+    tree = ET.ElementTree(root)
+    tree.write(outdir / "forms.xml", encoding="utf-8", xml_declaration=True)
+

--- a/src/crfgen/exporter/registry.py
+++ b/src/crfgen/exporter/registry.py
@@ -1,0 +1,16 @@
+_registry = {}
+
+def register(name: str):
+    def decorator(fn):
+        _registry[name] = fn
+        return fn
+    return decorator
+
+
+def get(name: str):
+    return _registry[name]
+
+
+def formats():
+    return list(_registry.keys())
+

--- a/src/crfgen/exporter/xlsx.py
+++ b/src/crfgen/exporter/xlsx.py
@@ -1,0 +1,19 @@
+from pathlib import Path
+from typing import Sequence
+import openpyxl
+
+from crfgen.schema import Form
+from .registry import register
+
+
+@register("xlsx")
+def export_xlsx(forms: Sequence[Form], outdir: Path) -> None:
+    path = outdir / "forms.xlsx"
+    wb = openpyxl.Workbook()
+    ws = wb.active
+    ws.append(["domain", "oid", "prompt"])
+    for form in forms:
+        for fld in form.fields:
+            ws.append([form.domain, fld.oid, fld.prompt])
+    wb.save(path)
+

--- a/tests/test_build_cli.py
+++ b/tests/test_build_cli.py
@@ -1,0 +1,29 @@
+import subprocess
+import sys
+import pathlib
+import pytest
+
+
+@pytest.mark.parametrize("fmt", [["md"], ["csv"], ["md", "csv"]])
+def test_build_cli(tmp_path: pathlib.Path, fmt):
+    cmd = [
+        sys.executable,
+        "scripts/build.py",
+        "--source",
+        "tests/.data/sample_crf.json",
+        "--outdir",
+        str(tmp_path),
+        "--formats",
+        *fmt,
+    ]
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    assert result.returncode == 0, result.stderr
+
+    for f in fmt:
+        if f == "md":
+            assert any(tmp_path.glob("*.md"))
+        elif f == "csv":
+            assert (tmp_path / "forms.csv").exists()
+        elif f == "tex":
+            assert any(tmp_path.glob("*.tex"))
+


### PR DESCRIPTION
## Summary
- implement dispatcher script `scripts/build.py`
- add exporter registry and simple exporters
- smoke test the build CLI with unit tests
- set up GitHub Actions workflow to run build and tests

## Testing
- `poetry run scripts/build.py --source tests/.data/sample_crf.json --outdir tmp_artifacts --formats md csv tex`
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687edde93510832cb564a0b8f0aae2f4