### PR TITLE
Improve generated CRFs

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,12 @@ secrets are supplied as bytes.
 ## Generating CDASH CRFs
 
 The repository includes `scripts/generate_cdash_crf.py` which converts the
-official CDASH workbooks into simple Word documents—one per domain.  The script
-requires `pandas`, `python-docx` and `openpyxl` which are already listed in the
-project dependencies.
+official CDASH workbooks into Word documents—one per domain.  The script now
+adds extra metadata from the IG such as variable type, controlled terminology
+and completion instructions.  Generated CRFs use a consistent landscape layout
+with protocol information in the header and versioned footers with page numbers.
+`pandas`, `python-docx` and `openpyxl` are already listed in the project
+dependencies.
 
 ```bash
 python scripts/generate_cdash_crf.py \
@@ -27,5 +30,5 @@ python scripts/generate_cdash_crf.py --model CDASH_Model_v1.3.xlsx \
 ```
 
 Edit `build_domain_crf()` in the script to customise the table layout or add
-study branding.
+study branding or adjust fonts and orientation if needed.
 

--- a/scripts/generate_cdash_crf.py
+++ b/scripts/generate_cdash_crf.py
@@ -6,6 +6,28 @@ import pathlib
 
 import pandas as pd
 from docx import Document
+from docx.enum.section import WD_ORIENT
+from docx.enum.text import WD_ALIGN_PARAGRAPH
+from docx.oxml import OxmlElement
+from docx.oxml.ns import qn
+from docx.shared import Pt
+
+
+def _add_page_field(paragraph):
+    """Insert a Word page number field into *paragraph*."""
+    run = paragraph.add_run()
+    fld_char_begin = OxmlElement("w:fldChar")
+    fld_char_begin.set(qn("w:fldCharType"), "begin")
+    run._r.append(fld_char_begin)
+
+    instr = OxmlElement("w:instrText")
+    instr.set(qn("xml:space"), "preserve")
+    instr.text = "PAGE"
+    run._r.append(instr)
+
+    fld_char_end = OxmlElement("w:fldChar")
+    fld_char_end.set(qn("w:fldCharType"), "end")
+    run._r.append(fld_char_end)
 
 
 def load_ig(ig_path: str) -> pd.DataFrame:
@@ -16,29 +38,103 @@ def load_ig(ig_path: str) -> pd.DataFrame:
         ig_df["CDASHIG Variable Label"]
     )
     ig_df.rename(
-        columns={"CDASHIG Variable": "Variable", "Variable Order": "Order"},
+        columns={
+            "CDASHIG Variable": "Variable",
+            "Variable Order": "Order",
+            "Case Report Form Completion Instructions": "CRF Instructions",
+            "CDISC CT Codelist Submission Values(s), Subset Submission Value(s)": "CT Values",
+            "CDISC CT Codelist Code(s), Subset Codes(s)": "CT Codes",
+        },
         inplace=True,
     )
     return ig_df
 
 
-def build_domain_crf(domain_df: pd.DataFrame, domain: str, out_dir: pathlib.Path) -> None:
+def build_domain_crf(
+    domain_df: pd.DataFrame, domain: str, out_dir: pathlib.Path
+) -> None:
     """Create a Word document for a single CDASH domain."""
 
     document = Document()
+
+    # Use landscape orientation for readability
+    section = document.sections[0]
+    section.orientation = WD_ORIENT.LANDSCAPE
+    section.page_width, section.page_height = section.page_height, section.page_width
+
+    # Standardise font
+    style = document.styles["Normal"]
+    style.font.name = "Arial"
+    style.font.size = Pt(10)
+
+    # Header placeholders for protocol metadata
+    hdr_tbl = section.header.add_table(
+        rows=1,
+        cols=3,
+        width=section.page_width - section.left_margin - section.right_margin,
+    )
+    hdr_tbl.style = "Table Grid"
+    hdr_cells = hdr_tbl.rows[0].cells
+    hdr_cells[0].text = "Protocol ID: __________"
+    hdr_cells[1].text = "Site Code: __________"
+    hdr_cells[2].text = "Subject ID: __________"
+
+    # Footer with version and automatic page numbering
+    f_p = section.footer.add_paragraph("CRF Version 1.0 ")
+    _add_page_field(f_p)
+    f_p.alignment = WD_ALIGN_PARAGRAPH.RIGHT
+
     document.add_heading(f"{domain} Domain CRF", level=1)
 
-    table = document.add_table(rows=1, cols=3)
+    # Add a table with extra metadata columns to provide more context
+    table = document.add_table(rows=1, cols=6, style="Table Grid")
     hdr = table.rows[0].cells
     hdr[0].text = "Variable"
     hdr[1].text = "Label / Question"
-    hdr[2].text = "Data Entry"
+    hdr[2].text = "Type"
+    hdr[3].text = "Controlled Terminology"
+    hdr[4].text = "Data Entry"
+    hdr[5].text = "Instructions"
 
     for _, row in domain_df.sort_values("Order").iterrows():
         cells = table.add_row().cells
         cells[0].text = row["Variable"]
         cells[1].text = str(row["Display Label"])
-        cells[2].text = "_______________________________"
+        cells[2].text = str(row.get("Type", ""))
+
+        ct_val = row.get("CT Values")
+        ct_code = row.get("CT Codes")
+        if pd.notna(ct_val):
+            ct = str(ct_val)
+        elif pd.notna(ct_code):
+            ct = str(ct_code)
+        else:
+            ct = ""
+        cells[3].text = ct
+
+        # Placeholder where data should be recorded
+        cells[4].text = "_______________"
+
+        instructions = []
+        if pd.notna(row.get("CRF Instructions")):
+            instructions.append(str(row.get("CRF Instructions")))
+        if pd.notna(row.get("Implementation Notes")):
+            instructions.append(str(row.get("Implementation Notes")))
+        label_lower = str(row.get("Display Label", "")).lower()
+        var_upper = row["Variable"].upper()
+        if (
+            "date" in label_lower
+            or var_upper.endswith("DT")
+            or var_upper.endswith("DAT")
+        ):
+            instructions.append("Format: dd/mm/yyyy")
+
+        instr_para = cells[5].paragraphs[0]
+        for idx, item in enumerate(instructions):
+            run = instr_para.add_run(item)
+            run.italic = True
+            if idx < len(instructions) - 1:
+                instr_para.add_run("\n")
 
     out_path = out_dir / f"{domain}_CRF.docx"
     document.save(out_path)

--- a/tests/test_generate_cdash_crf.py
+++ b/tests/test_generate_cdash_crf.py
@@ -10,3 +10,24 @@ def test_help():
     )
     assert result.returncode == 0, result.stderr
     assert "Generate Word CRFs" in result.stdout
+
+
+def test_generate_sample(tmp_path):
+    output = tmp_path / "out"
+    cmd = [
+        sys.executable,
+        "scripts/generate_cdash_crf.py",
+        "--model",
+        "tests/CDASH_Model_v1.3.xlsx",
+        "--ig",
+        "tests/CDASHIG_v2.3 (1).xlsx",
+        "--out",
+        str(output),
+        "--domains",
+        "AE",
+        "DM",
+    ]
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    assert result.returncode == 0, result.stderr
+    assert (output / "AE_CRF.docx").exists()
+    assert (output / "DM_CRF.docx").exists()


### PR DESCRIPTION
## Summary
- enrich CDASH CRF script with extra fields from IG and nicer layout
- clarify README on CRF generator details
- make CRFs landscape, add header/footer and data entry placeholders
- fix header table width and add regression test for CRF generation

## Testing
- `pre-commit run --files scripts/generate_cdash_crf.py tests/test_generate_cdash_crf.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888cf0335bc832c80cc067a4b3a425a