### PR TITLE
Fix header table width for docx 1.1

### DIFF
--- a/scripts/generate_cdash_crf.py
+++ b/scripts/generate_cdash_crf.py
@@ -6,11 +6,11 @@ import pathlib
 
 import pandas as pd
 from docx import Document
-from docx.shared import Pt, Inches
 from docx.enum.section import WD_ORIENT
 from docx.enum.text import WD_ALIGN_PARAGRAPH
 from docx.oxml import OxmlElement
 from docx.oxml.ns import qn
+from docx.shared import Pt
 
 
 def _add_page_field(paragraph):
@@ -50,7 +50,9 @@ def load_ig(ig_path: str) -> pd.DataFrame:
     return ig_df
 
 
-def build_domain_crf(domain_df: pd.DataFrame, domain: str, out_dir: pathlib.Path) -> None:
+def build_domain_crf(
+    domain_df: pd.DataFrame, domain: str, out_dir: pathlib.Path
+) -> None:
     """Create a Word document for a single CDASH domain."""
 
     document = Document()
@@ -66,7 +68,8 @@ def build_domain_crf(domain_df: pd.DataFrame, domain: str, out_dir: pathlib.Path
     style.font.size = Pt(10)
 
     # Header placeholders for protocol metadata
-    hdr_tbl = section.header.add_table(rows=1, cols=3)
+    hdr_width = section.page_width - section.left_margin - section.right_margin
+    hdr_tbl = section.header.add_table(rows=1, cols=3, width=hdr_width)
     hdr_tbl.style = "Table Grid"
     hdr_cells = hdr_tbl.rows[0].cells
     hdr_cells[0].text = "Protocol ID: __________"
@@ -116,7 +119,11 @@ def build_domain_crf(domain_df: pd.DataFrame, domain: str, out_dir: pathlib.Path
             instructions.append(str(row.get("Implementation Notes")))
         label_lower = str(row.get("Display Label", "")).lower()
         var_upper = row["Variable"].upper()
-        if "date" in label_lower or var_upper.endswith("DT") or var_upper.endswith("DAT"):
+        if (
+            "date" in label_lower
+            or var_upper.endswith("DT")
+            or var_upper.endswith("DAT")
+        ):
             instructions.append("Format: dd/mm/yyyy")
 
         instr_para = cells[5].paragraphs[0]

--- a/tests/test_generate_cdash_crf.py
+++ b/tests/test_generate_cdash_crf.py
@@ -10,3 +10,25 @@ def test_help():
     )
     assert result.returncode == 0, result.stderr
     assert "Generate Word CRFs" in result.stdout
+
+
+def test_generate(tmp_path):
+    out_dir = tmp_path / "out"
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/generate_cdash_crf.py",
+            "--model",
+            "tests/CDASH_Model_v1.3.xlsx",
+            "--ig",
+            "tests/CDASHIG_v2.3 (1).xlsx",
+            "--out",
+            str(out_dir),
+            "--domains",
+            "AE",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+    assert (out_dir / "AE_CRF.docx").exists()


### PR DESCRIPTION
## Summary
- update header table creation to include width
- test generate_cdash_crf CLI end-to-end

## Testing
- `pre-commit run --files scripts/generate_cdash_crf.py tests/test_generate_cdash_crf.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888e787e69c832c8278ff4a51751cdf