### PR TITLE
Fix: Skip pre-commit install in CI

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -91,10 +91,13 @@ poetry install
 echo "Dependencies installed successfully."
 
 echo "Installing pre-commit hooks..."
-# Unset core.hooksPath to allow pre-commit to install hooks
-git config --global --unset-all core.hooksPath
-poetry run pre-commit install
-
-echo "Pre-commit hooks installed successfully."
+if [ -z "$CI" ]; then
+    # Unset core.hooksPath to allow pre-commit to install hooks
+    git config --global --unset-all core.hooksPath
+    poetry run pre-commit install
+    echo "Pre-commit hooks installed successfully."
+else
+    echo "Skipping pre-commit hook installation in CI environment."
+fi
 
 echo "Setup complete. The development environment is ready."


### PR DESCRIPTION
The `setup.sh` script was failing in the CI environment during the `poetry run pre-commit install` step. This step is unnecessary for the CI pipeline, as the subsequent `pre-commit run` command checks all files regardless of whether the hooks are installed.

This change modifies the `setup.sh` script to check for the `CI` environment variable. If the variable is set, the pre-commit hook installation is skipped, resolving the CI failure.
