### PR TITLE
feat: Add validation for CDISC_PRIMARY_KEY

### DIFF
--- a/scripts/build_canonical.py
+++ b/scripts/build_canonical.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python
 import argparse
-import os
 import sys
 
+from crfgen.auth import get_api_key
 from crfgen.crawl import harvest, write_json
 
 p = argparse.ArgumentParser()
@@ -10,9 +10,10 @@ p.add_argument("-o", "--out", default="crf.json")
 p.add_argument("-v", "--version", help="IG version substring (optional)")
 args = p.parse_args()
 
-token = os.getenv("CDISC_PRIMARY_KEY")
-if not token:
-    sys.exit("ERROR: set CDISC_PRIMARY_KEY environment variable")
+try:
+    token = get_api_key()
+except ValueError as e:
+    sys.exit(f"ERROR: {e}")
 
 forms = harvest(token, ig_filter=args.version)
 write_json(forms, args.out)

--- a/src/crfgen/auth.py
+++ b/src/crfgen/auth.py
@@ -1,0 +1,14 @@
+"""
+Authentication utilities.
+"""
+import os
+
+DUMMY_VALUES = {"", "dummy-key", "***"}
+
+
+def get_api_key() -> str:
+    """Get CDISC Library API key from env and validate it."""
+    token = os.getenv("CDISC_PRIMARY_KEY")
+    if not token or token in DUMMY_VALUES:
+        raise ValueError("CDISC_PRIMARY_KEY is not set correctly")
+    return token

--- a/tests/test_crawl_live.py
+++ b/tests/test_crawl_live.py
@@ -1,13 +1,18 @@
-import os
-
 import pytest
 
+from crfgen.auth import get_api_key
 from crfgen.crawl import harvest
 
-token = os.getenv("CDISC_PRIMARY_KEY")
+try:
+    token = get_api_key()
+    skip_test = False
+except ValueError as e:
+    token = None
+    skip_test = True
+    reason = str(e)
 
 
-@pytest.mark.skipif(not token, reason="no API key in env")
+@pytest.mark.skipif(skip_test, reason=reason)
 def test_live_pull_small():
     forms = harvest(token, ig_filter="2-2")
     assert len(forms) >= 40  # CDASH 2.2 domains


### PR DESCRIPTION
Adds a validation function `get_api_key` to ensure that the `CDISC_PRIMARY_KEY` environment variable is set and does not contain placeholder values like 'dummy-key' or '***'.

This prevents the application from attempting to make API calls with an invalid key, which would result in a `ValueError: Invalid header value`.

The new function is used in the `build_canonical.py` script and the live tests, providing a clearer error message when the key is not configured correctly.
