### PR TITLE
Fix 404 error when fetching CDASHIG from CDISC Library

### DIFF
--- a/src/crfgen/crawl.py
+++ b/src/crfgen/crawl.py
@@ -34,12 +34,13 @@ def harvest(token: str, ig_filter: Optional[str] = None) -> List[Form]:
     """Pull CDASH IG -> domains -> scenarios and convert to Form objects."""
     if isinstance(token, (bytes, bytearray)):
         token = token.decode()
-    root = _json(f"{BASE}/mdr/cdashig", token)
+    products = _json(f"{BASE}/mdr/products/DataCollection", token)
+    cdashig_links = products["_links"]["cdashig"]
     forms: list[Form] = []
-    for ver in root["_links"]["versions"]:
-        if ig_filter and ig_filter not in ver["title"]:
+    for ver_link in cdashig_links:
+        if ig_filter and ig_filter not in ver_link["title"]:
             continue
-        ig = _json(ver["href"], token)
+        ig = _json(ver_link["href"], token)
         for dom_link in ig["_links"]["domains"]:
             dom = _json(dom_link["href"], token)
             scenarios = dom["_links"].get("scenarios") or []

--- a/src/crfgen/http.py
+++ b/src/crfgen/http.py
@@ -32,6 +32,11 @@ def cached_get(url: str, headers: dict[str, str], ttl_days: int = 30) -> Any:
 
     sess = _retry_session()
     r = sess.get(url, headers=headers, timeout=30)
-    r.raise_for_status()
+    try:
+        r.raise_for_status()
+    except requests.exceptions.HTTPError as e:
+        if r.status_code == 404:
+            raise RuntimeError(f"Resource not found: {url}") from e
+        raise
     fname.write_text(r.text)
     return r.json()

--- a/tests/fixtures/crawl_fixture.json
+++ b/tests/fixtures/crawl_fixture.json
@@ -1,7 +1,7 @@
 {
-  "https://library.cdisc.org/api/mdr/cdashig": {
+  "https://library.cdisc.org/api/mdr/products/DataCollection": {
     "_links": {
-      "versions": [
+      "cdashig": [
         {"href": "https://library.cdisc.org/api/mdr/cdashig/2-2", "title": "CDASHIG 2-2"}
       ]
     }
@@ -14,23 +14,16 @@
     }
   },
   "https://library.cdisc.org/api/mdr/cdashig/2-2/domains/VS": {
-    "title": "Vital Signs",
-    "domain": "VS",
     "_links": {
       "scenarios": [
         {"href": "https://library.cdisc.org/api/mdr/cdashig/2-2/scenarios/VS.Generic"}
       ]
     },
-    "fields": [
-      {"cdash_variable": "VSORRES", "prompt": "Result", "datatype": "text"}
-    ]
+    "name": "VS",
+    "label": "Vital Signs"
   },
   "https://library.cdisc.org/api/mdr/cdashig/2-2/scenarios/VS.Generic": {
-    "title": "VS Generic Scenario",
-    "domain": "VS",
-    "scenario": "VS.Generic",
-    "fields": [
-      {"cdash_variable": "VSDTC", "prompt": "Date/Time", "datatype": "datetime"}
-    ]
+    "name": "VS.Generic",
+    "label": "Vital Signs Generic"
   }
 }


### PR DESCRIPTION
The API endpoint for fetching the list of CDASHIG versions has changed. The previous endpoint `/mdr/cdashig` is no longer valid and returns a 404 error.

This commit updates the code to use the new endpoint `/mdr/products/DataCollection` to fetch the list of CDASHIG products. It then iterates through the products to get the different versions of CDASHIG.

Additionally, error handling has been added to the `cached_get` function to provide a more informative error message in case of a 404 error in the future.