### PR TITLE
Refactor API client usage and fix authentication

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1738,4 +1738,4 @@ docs = ["jinja2", "sphinx", "sphinx_rtd_theme"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<4.0"
-content-hash = "f58d8b6215282a536f9589afed1bdf186dfbf84f3526473f4649f4f009e220f4"
+content-hash = "f27f3d09faac66da75357c2d60c7fce100b7265fe140cde0531d7e18aa2fec68"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ pandas = "^2.2"
 openpyxl = "^3.1"
 python-docx = "^1.1"
 odmlib = {git = "https://github.com/swhume/odmlib.git", rev = "57b8ae069b1d6783cf73b8860b85dee6be0853ed"}
+httpx = "^0.28.1"
 
 [tool.poetry.group.dev.dependencies]
 black = "^25.1.0"

--- a/scripts/build_canonical.py
+++ b/scripts/build_canonical.py
@@ -2,7 +2,7 @@
 import argparse
 import sys
 
-from crfgen.auth import get_api_key
+from crfgen.auth import get_client
 from crfgen.crawl import harvest, write_json
 
 p = argparse.ArgumentParser()
@@ -11,10 +11,10 @@ p.add_argument("-v", "--version", help="IG version substring (optional)")
 args = p.parse_args()
 
 try:
-    token = get_api_key()
+    client = get_client()
 except ValueError as e:
     sys.exit(f"ERROR: {e}")
 
-forms = harvest(token, ig_filter=args.version)
+forms = harvest(client, ig_filter=args.version)
 write_json(forms, args.out)
 print(f"✅  Saved {len(forms)} forms -> {args.out}")

--- a/src/crfgen/auth.py
+++ b/src/crfgen/auth.py
@@ -4,7 +4,12 @@ Authentication utilities.
 
 import os
 
+import httpx
+from cdisc_library_client.client import AuthenticatedClient
+
 DUMMY_VALUES = {"", "dummy-key", "***"}
+BASE = "https://library.cdisc.org/api"
+ACCEPT = "application/vnd.cdisc+json"
 
 
 def get_api_key() -> str:
@@ -13,3 +18,21 @@ def get_api_key() -> str:
     if not token or token in DUMMY_VALUES:
         raise ValueError("CDISC_PRIMARY_KEY is not set correctly")
     return token
+
+
+def get_client() -> AuthenticatedClient:
+    """
+    Get an authenticated client for the CDISC Library API.
+    """
+    token = get_api_key()
+    transport = httpx.HTTPTransport(retries=5)
+    client = AuthenticatedClient(
+        base_url=BASE,
+        token=token,
+        headers={"Accept": ACCEPT},
+        auth_header_name="api-key",
+        prefix="",
+        timeout=30.0,
+        httpx_args={"transport": transport},
+    )
+    return client

--- a/src/crfgen/crawl.py
+++ b/src/crfgen/crawl.py
@@ -10,41 +10,29 @@ from crfgen.converter import form_from_api
 from crfgen.http import cached_get
 from crfgen.schema import Form
 
-BASE = "https://library.cdisc.org/api"
-ACCEPT = "application/vnd.cdisc+json"
 DELAY = 0.2  # seconds between calls (<= 60 req/min)
 
 
-def _client(token: str) -> AuthenticatedClient:
-    if isinstance(token, (bytes, bytearray)):
-        token = token.decode()
-    return AuthenticatedClient(base_url=BASE, token=str(token), timeout=30.0)
-
-
-def _json(url: str, token: str):
-    if isinstance(token, (bytes, bytearray)):
-        token = token.decode()
-    headers = {"Authorization": f"Bearer {token}", "Accept": ACCEPT}
-    data = cached_get(url, headers)
+def _json(client: AuthenticatedClient, url: str):
+    data = cached_get(client, url)
     time.sleep(DELAY)
     return data
 
 
-def harvest(token: str, ig_filter: Optional[str] = None) -> List[Form]:
+def harvest(client: AuthenticatedClient, ig_filter: Optional[str] = None) -> List[Form]:
     """Pull CDASH IG -> domains -> scenarios and convert to Form objects."""
-    if isinstance(token, (bytes, bytearray)):
-        token = token.decode()
-    products = _json(f"{BASE}/mdr/products/DataCollection", token)
+    base_url = str(client.get_httpx_client().base_url)
+    products = _json(client, f"{base_url}/mdr/products/DataCollection")
     cdashig_links = products["_links"]["cdashig"]
     forms: list[Form] = []
     for ver_link in cdashig_links:
         if ig_filter and ig_filter not in ver_link["title"]:
             continue
-        ig = _json(ver_link["href"], token)
+        ig = _json(client, ver_link["href"])
         for dom_link in ig["_links"]["domains"]:
-            dom = _json(dom_link["href"], token)
+            dom = _json(client, dom_link["href"])
             scenarios = dom["_links"].get("scenarios") or []
-            payloads = [dom] + [_json(s["href"], token) for s in scenarios]
+            payloads = [dom] + [_json(client, s["href"]) for s in scenarios]
             for p in payloads:
                 forms.append(form_from_api(p))
     return forms

--- a/src/crfgen/http.py
+++ b/src/crfgen/http.py
@@ -1,5 +1,5 @@
 """
-Light wrapper around requests to add retry/back-off and
+Light wrapper around httpx to add
 JSON disk-cache (protects Library quota & speeds tests).
 """
 
@@ -10,33 +10,29 @@ import pathlib
 import time
 from typing import Any
 
-import requests
-from requests.adapters import HTTPAdapter
-from urllib3.util.retry import Retry
+import httpx
+from cdisc_library_client.client import AuthenticatedClient
 
 CACHE_DIR = pathlib.Path(".cache")
 CACHE_DIR.mkdir(exist_ok=True)
 
 
-def _retry_session() -> requests.Session:
-    r = Retry(total=5, backoff_factor=0.4, status_forcelist=[502, 503, 504, 429])
-    s = requests.Session()
-    s.mount("https://", HTTPAdapter(max_retries=r))
-    return s
-
-
-def cached_get(url: str, headers: dict[str, str], ttl_days: int = 30) -> Any:
+def cached_get(client: AuthenticatedClient, url: str, ttl_days: int = 30) -> Any:
+    """
+    A cached GET request that uses the AuthenticatedClient.
+    """
     fname = CACHE_DIR / (url.replace("/", "_").replace(":", "") + ".json")
     if fname.exists() and (time.time() - fname.stat().st_mtime) < ttl_days * 86400:
         return json.loads(fname.read_text())
 
-    sess = _retry_session()
-    r = sess.get(url, headers=headers, timeout=30)
+    httpx_client = client.get_httpx_client()
     try:
+        r = httpx_client.get(url)
         r.raise_for_status()
-    except requests.exceptions.HTTPError as e:
-        if r.status_code == 404:
+    except httpx.HTTPStatusError as e:
+        if e.response.status_code == 404:
             raise RuntimeError(f"Resource not found: {url}") from e
         raise
+
     fname.write_text(r.text)
     return r.json()


### PR DESCRIPTION
This commit refactors the CRF generation scripts to use the provided `AuthenticatedClient` from the `cdisc_library_client` package, replacing the manual `requests`-based implementation.

The key changes are:
- The `AuthenticatedClient` is now configured to use the `api-key` header for authentication, as required by the CDISC Library API documentation. The previous implementation was incorrectly using an `Authorization: Bearer` header.
- The code has been centralized in `src/crfgen/auth.py` to create a properly configured and authenticated client, which is then used throughout the application.
- The `requests`-based HTTP calls in `src/crfgen/http.py` have been replaced with `httpx` calls through the `AuthenticatedClient`.
- The main script and supporting functions have been updated to pass the client object instead of a raw token.
- Added `httpx` as a direct dependency to `pyproject.toml` to ensure it is available in the environment.

This change fixes the 401 authentication error and improves the code's structure and maintainability.